### PR TITLE
Adding CacheDuration to cached items so they can expire.

### DIFF
--- a/Source/HaloSharp.Test/CacheTests.cs
+++ b/Source/HaloSharp.Test/CacheTests.cs
@@ -1,0 +1,43 @@
+﻿using NUnit.Framework;
+using System;
+
+namespace HaloSharp.Test.Utility
+{
+    [TestFixture]
+    public class CacheTests
+    {
+        private TimeSpan PreviousCacheDuration;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.PreviousCacheDuration = Cache.CacheDuration;
+        }
+
+        [Test]
+        public void CachedValueShouldBeNullIfExpired()
+        {
+            // Cached items will expire as soon as they enter the cache
+            Cache.CacheDuration = TimeSpan.Zero;
+
+            Cache.Add("key", "value");
+            var cachedValue = Cache.Get<string>("key");
+            Assert.IsNull(cachedValue, "cached value should be expired");
+        }
+
+        [Test]
+        public void CachedValueShouldBeCorrectIfNotExpired()
+        {
+            var value = "value";
+            Cache.Add("key", value);
+            var cachedValue = Cache.Get<string>("key");
+            Assert.AreEqual(value, value);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Cache.CacheDuration = this.PreviousCacheDuration;
+        }
+    }
+}

--- a/Source/HaloSharp.Test/HaloSharp.Test.csproj
+++ b/Source/HaloSharp.Test/HaloSharp.Test.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Query\Stats\Lifetime\GetWarzoneServiceRecordTests.cs" />
     <Compile Include="Schema\SchemaTests.cs" />
     <Compile Include="Serialization\SerializationTests.cs" />
+    <Compile Include="CacheTests.cs" />
     <Compile Include="Utility\SchemaUtility.cs" />
     <Compile Include="Utility\SerializationUtility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -328,7 +329,9 @@
       <Name>HaloSharp</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Source/HaloSharp/Cache.cs
+++ b/Source/HaloSharp/Cache.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Caching;
+﻿using System;
+using System.Runtime.Caching;
 
 namespace HaloSharp
 {
@@ -7,13 +8,15 @@ namespace HaloSharp
         private static readonly ObjectCache ObjectCache = MemoryCache.Default;
         private static readonly object LockObject = new object();
 
+        public static TimeSpan CacheDuration = TimeSpan.FromMinutes(10);
+
         public static void Add<T>(string key, T toAdd) where T : class
         {
             lock (LockObject)
             {
                 if (toAdd != null)
                 {
-                    ObjectCache[key] = toAdd;
+                    ObjectCache.Add(key, toAdd, new DateTimeOffset(DateTime.Now).ToOffset(CacheDuration));
                 }
             }
         }

--- a/Source/HaloSharp/Properties/AssemblyInfo.cs
+++ b/Source/HaloSharp/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.2.3.0")]
 [assembly: AssemblyFileVersion("1.2.3.0")]
+
+[assembly: InternalsVisibleToAttribute("HaloSharp.Test")]


### PR DESCRIPTION
I noticed that stuff like seasons are getting cached but, when a new season gets created, you won't be able to retrieve it unless you intentionally skip the cache. This allows for a caller to get that value at some point.